### PR TITLE
Remove explicit Gradle wrapper task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,3 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.assertj:assertj-core:2.5.0'
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
-}


### PR DESCRIPTION
As described in [Gradle's user guide](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:wrapper_generation), explicit wrapper task is not required (since Gradle 2.4).

This also has an advantage of not needing to modify build script when upgrading the Gradle to a new version.