### PR TITLE
Upgrade Dependency management plugin to 0.6.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'io.spring.gradle:dependency-management-plugin:0.5.5.RELEASE'
+    compile 'io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.assertj:assertj-core:2.5.0'


### PR DESCRIPTION
Some Spring projects have moved to Gradle 3, and the current version of IO plugin doesn't work in such setup OOTB due to spring-gradle-plugins/dependency-management-plugin#87, so manual upgrade of the Dependency management plugin is required.