### PR TITLE
URL Cleanup

### DIFF
--- a/.wrapper/gradle-wrapper.properties
+++ b/.wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven'
 group = 'io.spring.gradle'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
     maven { url 'https://repo.spring.io/plugins-release' }
 }
 

--- a/samples/spring-io-sample-sanitychecks/build.gradle
+++ b/samples/spring-io-sample-sanitychecks/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'groovy'
 apply plugin: 'spring-io'
 
 repositories {
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 	maven { url 'https://repo.spring.io/libs-snapshot'}
 }
 


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.